### PR TITLE
Export labels as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 4. [Labels](./docs/label.md)
 5. [Features](./docs/features.md)
 6. [Payment Tracking](./docs/making_payments.md)
-7. [Troubleshooting](./docs/troubleshoot.md)
+7.  [Useful SQL queries](./docs/useful_sql_queries.md)
+8. [Troubleshooting](./docs/troubleshoot.md)
 
 ## Installation
 

--- a/backend/unit_test_data/init_unit_test_data.sql
+++ b/backend/unit_test_data/init_unit_test_data.sql
@@ -54,12 +54,12 @@ INSERT INTO labels (input_data_id, label_task_id, user_id) VALUES (3, 2, 1);
 INSERT INTO labels (input_data_id, label_task_id, user_id, admin_complete) VALUES (3, 1, 2, true);
 INSERT INTO labels (input_data_id, label_task_id, user_id, in_progress, user_complete, admin_complete) VALUES (4, 1, 3, true, true, true);
 
-INSERT INTO label_history (label_id, label_serialised) VALUES (2, '[{"test": 123}]');
-INSERT INTO label_history (label_id, label_serialised) VALUES (2, '[{"test": 1234}]');
-INSERT INTO label_history (label_id, label_serialised) VALUES (1, '[{"test": 1}]');
-INSERT INTO label_history (label_id, label_serialised) VALUES (3, '[{"test": 4}]');
-INSERT INTO label_history (label_id, label_serialised) VALUES (4, '[{"test": 5}]');
-INSERT INTO label_history (label_id, label_serialised) VALUES (5, '[{"type": "freehand", "label": "foreground_object", "polygon": {"regions": [[[100.2, 200.1], [130.4, 205.1], [132.2, 270.1], [102.1, 268.7]]], "inverted": false}, "selected": true}]');
+INSERT INTO label_history (label_id, label_serialised) VALUES (2, '[{"type": "freehand", "label": "foreground_object", "polygon": {"regions": [[[100.2, 200.1], [130.4, 205.1], [132.2, 270.1], [102.1, 268.7]]], "inverted": false}, "selected": true}]');
+INSERT INTO label_history (label_id, label_serialised) VALUES (2, '[{"type": "freehand", "label": "foreground_object", "polygon": {"regions": [[[100.2, 200.1], [130.4, 205.1], [132.2, 270.1], [102.1, 268.7]]], "inverted": false}, "selected": true}]');
+INSERT INTO label_history (label_id, label_serialised) VALUES (1, '[{"type": "freehand", "label": "foreground_object", "polygon": {"regions": [[[100.2, 200.1], [130.4, 205.1], [132.2, 270.1], [102.1, 268.7]]], "inverted": false}, "selected": true}]');
+INSERT INTO label_history (label_id, label_serialised) VALUES (3, '[{"type": "freehand", "label": "foreground_object", "polygon": {"regions": [[[100, 200], [130, 205], [132, 270], [102, 268]]], "inverted": false}, "selected": true}]');
+INSERT INTO label_history (label_id, label_serialised) VALUES (4, '[{"type": "rectangle", "label": {"x": 95, "y": 69.21875, "boxWidth": 260, "boxHeight": 117}, "selected": true, "label_class": "foreground_object"}]');
+INSERT INTO label_history (label_id, label_serialised) VALUES (5, '[{"type": "polygon", "label": "foreground_object", "polygon": {"regions": [[[100.2, 200.1], [130.4, 205.1], [132.2, 270.1], [102.1, 268.7]]], "inverted": false}, "selected": true}]');
 
 INSERT INTO priorities(input_data_id, label_task_id, priority) VALUES (1, 1, 1);
 INSERT INTO priorities(input_data_id, label_task_id, priority) VALUES (2, 1, 5);

--- a/backend/unit_tests/test_endpoints.py
+++ b/backend/unit_tests/test_endpoints.py
@@ -87,7 +87,9 @@ def test_get_latest_label_history_for_logged_in_user(auth, refresh_db_once):
     label = json_of_response(rv_label)
 
     assert label[0]['label_id'] == 3
-    assert label[0]['label_serialised'] == '[{"test": 4}]'
+    assert label[0]['label_serialised'] == '[{"type": "freehand", "label": "foreground_object", "polygon": ' \
+                                           '{"regions": [[[100, 200], [130, 205], [132, 270], [102, 268]]], ' \
+                                           '"inverted": false}, "selected": true}]'
     assert label[0]['input_data_id'] == 3
     assert label[0]['label_task_id'] == 1
     assert label[0]['user_id'] == 1
@@ -103,7 +105,7 @@ def test_get_latest_label_history_for_different_logged_in_user(auth, refresh_db_
     label = json_of_response(rv_label)
 
     assert label[0]['label_id'] == 5
-    assert label[0]['label_serialised'] == '[{"type": "freehand", "label": "foreground_object", ' \
+    assert label[0]['label_serialised'] == '[{"type": "polygon", "label": "foreground_object", ' \
                                            '"polygon": {"regions": [[[100.2, 200.1], [130.4, 205.1], ' \
                                            '[132.2, 270.1], [102.1, 268.7]]], "inverted": false}, "selected": true}]'
     assert label[0]['input_data_id'] == 3
@@ -121,7 +123,9 @@ def test_get_latest_label_history_for_specified_user(auth, refresh_db_once):
     label = json_of_response(rv_label)
 
     assert label[0]['label_id'] == 3
-    assert label[0]['label_serialised'] == '[{"test": 4}]'
+    assert label[0]['label_serialised'] == '[{"type": "freehand", "label": "foreground_object", "polygon": ' \
+                                           '{"regions": [[[100, 200], [130, 205], [132, 270], [102, 268]]], ' \
+                                           '"inverted": false}, "selected": true}]'
     assert label[0]['input_data_id'] == 3
     assert label[0]['label_task_id'] == 1
     assert label[0]['user_id'] == 1
@@ -133,7 +137,7 @@ def test_get_latest_label_history_for_specified_user(auth, refresh_db_once):
     label = json_of_response(rv_label)
 
     assert label[0]['label_id'] == 5
-    assert label[0]['label_serialised'] == '[{"type": "freehand", "label": "foreground_object", ' \
+    assert label[0]['label_serialised'] == '[{"type": "polygon", "label": "foreground_object", ' \
                                            '"polygon": {"regions": [[[100.2, 200.1], [130.4, 205.1], ' \
                                            '[132.2, 270.1], [102.1, 268.7]]], "inverted": false}, "selected": true}]'
     assert label[0]['input_data_id'] == 3
@@ -643,7 +647,6 @@ def test_download_ground_truth_images_to_disk(auth, refresh_db_every_time):
     assert response['num_ground_truth_images'] == 1
 
     assert os.path.exists('tmp/ground_truth_images/im_input_data_id_3_label_id_5_gt2.png')
-    assert not os.path.exists('tmp/ground_truth_images/im_input_data_id_4_label_id_6_gt2.png')
 
     assert dd.get_image_dims('tmp/ground_truth_images/im_input_data_id_3_label_id_5_gt2.png') == (640, 428)
 

--- a/backend/unit_tests/test_sql_select.py
+++ b/backend/unit_tests/test_sql_select.py
@@ -378,7 +378,9 @@ def test_get_latest_label(refresh_db_once, db_connection_sqlalchemy):
     df_test['label_id'] = [4]
     df_test['input_data_id'] = [3]
     df_test['in_progress'] = [False]
-    df_test['label_serialised'] = ['[{"test": 5}]']
+    df_test['label_serialised'] = ['[{"type": "rectangle", "label": {"x": 95, "y": 69.21875, '
+                                   '"boxWidth": 260, "boxHeight": 117}, "selected": true, '
+                                   '"label_class": "foreground_object"}]']
 
     engine = db_connection_sqlalchemy
     df = sql_queries.get_latest_label(engine, user_id=1, label_task_id=2, input_data_id=3)

--- a/docs/export_label.md
+++ b/docs/export_label.md
@@ -50,7 +50,7 @@ curl -X PUT \
 | center_dot                | Not yet tested, but it should generate a single dot at the centroid of each instance  |
 | filled_polygon_instances  | Generate filled polygons, where each instance has a different integer value           |
 
-*test_images* can be set to "true", "false" or the field can be omitted (default):
+*test_data* can be set to "true", "false" or the field can be omitted (default):
 
 | test_data         |                                                                                       |
 | -------------     |:-------------                                                                         |

--- a/docs/export_label.md
+++ b/docs/export_label.md
@@ -4,6 +4,8 @@
 
 There are currently two options for exporting the labels from the database via REST queries: getting all the raw JSON data or generating images from the labels.
 
+It is also possible to use a *SQL select* to query the *latest_label_history* table directly.
+ 
 ### Getting the raw JSON data
 
 ~~~ bash
@@ -62,18 +64,3 @@ curl -X PUT \
 | -------------   |:-------------                                                                         |
 | admin_complete  | Only generate ground truth images for data marked as "admin_complete" (i.e. admin user has approved this image)   |
 | user_complete   | Only generate ground truth images for data marked as "user_complete" (i.e. user has marked this image as complete, but admin user has not necessarily approved the labeling yet)                |
-
-## Useful SQL queries
-
-Delete duplicate input_data items from a particular dataset that has just been uploaded:
-
-~~~
-BEGIN;
-
-delete from input_data i using duplicate_input_data d where i.input_data_id = d.input_data_id and i.dataset_id = 17 and i.timestamp_upload is not null;
-
-select * from input_data where dataset_id = 17;
-
---rollback, so that we can test the query before executing (i.e. perform a dry run)
-ROLLBACK;
-~~~

--- a/docs/export_label.md
+++ b/docs/export_label.md
@@ -2,9 +2,29 @@
 
 ## How to generate ground truth labels and dump them to disk
 
-Use the following API call to generate ground truth image data:
+There are currently two options for exporting the labels from the database via REST queries: getting all the raw JSON data or generating images from the labels.
 
+### Getting the raw JSON data
+
+~~~ bash
+curl -X POST \
+  https://label.stonethree.com/image_labeler/api/v1.0/latest_label_history/label_task_id/5 \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Cache-Control: no-cache' \
+  -H 'Content-Type: application/json' \
+  -d '{
+	"test_images": "true",
+    "label_status": "admin_complete"
+}'
 ~~~
+
+The *test_data* and *label_status* fields are optional. Use these to further filter the labels returned.
+
+### Generate ground truth images from the labels
+
+Use the following API call to generate ground truth image data and dump it to disk (on the same machine where the backend is hosted):
+
+~~~ bash
 curl -X PUT \
   https://label.stonethree.com/image_labeler/api/v1.0/label_images/label_task_id/5 \
   -H 'Authorization: Bearer <token>' \
@@ -14,15 +34,9 @@ curl -X PUT \
 	"output_folder": "/tmp/ground_truth_images/label_task_5_test",
 	"suffix": "_gt4",
 	"gt_mode": "filled_polygon_instances",
-	"test_images": "true",
-  "label_status": "admin_complete"
+	"test_data": "true",
+    "label_status": "admin_complete"
 }'
-~~~
-
-Powershell:
-
-~~~
-curl -Method Put -Uri "https://label.stonethree.com/image_labeler/api/v1.0/label_images/label_task_id/5" -ContentType "application/json"
 ~~~
 
 *gt_mode* can be one of the following:
@@ -36,7 +50,7 @@ curl -Method Put -Uri "https://label.stonethree.com/image_labeler/api/v1.0/label
 
 *test_images* can be set to "true", "false" or the field can be omitted (default):
 
-| test_images       |                                                                                       |
+| test_data         |                                                                                       |
 | -------------     |:-------------                                                                         |
 | true              | Only generate ground truth images for data marked as "test data"                      |
 | false             | Only generate ground truth images for data *not* marked as "test data"                |

--- a/docs/useful_sql_queries.md
+++ b/docs/useful_sql_queries.md
@@ -1,0 +1,14 @@
+## Useful SQL queries
+
+Delete duplicate input_data items from a particular dataset that has just been uploaded:
+
+~~~ SQL
+BEGIN;
+
+delete from input_data i using duplicate_input_data d where i.input_data_id = d.input_data_id and i.dataset_id = 17 and i.timestamp_upload is not null;
+
+select * from input_data where dataset_id = 17;
+
+--rollback, so that we can test the query before executing (i.e. perform a dry run)
+ROLLBACK;
+~~~


### PR DESCRIPTION
Closes #3 and #34 

* Add endpoint for exporting all label data from a particular label task.
* Use correct label formats for test data in the database.