### PR TITLE
Add circle & point labeling, and 4th canvas layer

### DIFF
--- a/frontend/spa/src/components/ImageLabeling.vue
+++ b/frontend/spa/src/components/ImageLabeling.vue
@@ -5,12 +5,16 @@
             <div class="row justify-content-center">
                 <div id="tools" class="col border-right">
                     <span>Tools</span>
-                    <form id="tools_form">
+                    <form id="tools_form" @mousedown=changeRadio()>
                         <input type="radio" class="radio-button" name="tool" value="freehand" v-model="active_tool"> Freehand
                         <br>
                         <input type="radio" class="radio-button" name="tool" value="polygon" v-model="active_tool"> Polygon
                         <br>
                         <input type="radio" class="radio-button" name="tool" value="rectangle" v-model="active_tool"> Rectangle
+                        <br>
+                        <input type="radio" class="radio-button" name="tool" value="point" v-model="active_tool"> Point
+                        <br>
+                        <input type="radio" class="radio-button" name="tool" value="circle" v-model="active_tool"> Circle
                         <br>
                         <input type="radio" class="radio-button" name="tool" value="select" v-model="active_tool"> Select
                     </form>
@@ -97,6 +101,10 @@
                             v-bind:undo_event="undo_event"
                             v-bind:redo_event="redo_event"
                             v-bind:hide_labels="hide_labels"
+                            v-bind:increase_circle_event="increase_circle_event"
+                            v-bind:decrease_circle_event="decrease_circle_event"
+                            v-bind:change_radio_event ="change_radio_event"
+                            v-bind:switch_label_event="switch_label_event"
                             ref="mySubComponent"
                             class="row"
                             ></drawing-canvas>
@@ -163,6 +171,10 @@ export default {
             undo_event: false,
             redo_event: false,
             hide_labels: false,
+            increase_circle_event: false,
+            decrease_circle_event: false,
+            switch_label_event: false,
+            change_radio_event:false,
             label_examples: undefined,
             baseUrl: baseUrl,
             keyboard_shortcuts: [
@@ -243,6 +255,24 @@ export default {
                     this.stateOverlap = false;
                     this.stateNoOverlap = true;
                     break;
+                case 'point':
+                    this.active_mode = 'new';
+                    this.active_overlap_mode = 'overlap';
+                    this.stateNew = false;
+                    this.stateAppend = true;
+                    this.stateErase = true;
+                    this.stateOverlap = false;
+                    this.stateNoOverlap = true;
+                    break;
+                case 'circle':
+                    this.active_mode = 'new';
+                    this.active_overlap_mode = 'overlap';
+                    this.stateNew = false;
+                    this.stateAppend = true;
+                    this.stateErase = true;
+                    this.stateOverlap = false;
+                    this.stateNoOverlap = true;
+                    break;
                 case 'select':
                     this.stateNew = true;
                     this.stateAppend = true;
@@ -250,6 +280,7 @@ export default {
                     this.stateOverlap = true;
                     this.stateNoOverlap = true;
                     break;
+                
             }
         }
     },
@@ -474,10 +505,18 @@ export default {
                 }
 
                 key_handled = true;
+            } 
+            else if(e.code === 'NumpadAdd') {
+                this.increase_circle_event = !this.increase_circle_event;
+                key_handled = true;
+            } 
+            else if(e.code === 'NumpadSubtract') {
+                this.decrease_circle_event = !this.decrease_circle_event;
+                key_handled = true;
             }
             if ((e.keyCode >= 48 && e.keyCode <= 57) || (e.keyCode >= 96 && e.keyCode <= 105)) { 
                 // 0-9 only
-
+                this.switch_label_event = !this.switch_label_event;
                 let label_index = e.keyCode - 48;
 
                 if (label_index >= 1 && label_index <= this.labels.length) {
@@ -489,6 +528,7 @@ export default {
                     }
                 }
             }
+
 
             if (key_handled) {
                 e.stopPropagation();
@@ -538,6 +578,9 @@ export default {
         clearCanvas: function() {
             this.clear_canvas_event = !this.clear_canvas_event;
             console.log('clear canvas called', this.clear_canvas_event)
+        },
+        changeRadio: function(){
+            this.change_radio_event = !this.change_radio_event;
         },
 
     },

--- a/frontend/spa/static/DrawingOperations.js
+++ b/frontend/spa/static/DrawingOperations.js
@@ -20,11 +20,66 @@ export function drawAllLabels(vm, labels_list) {
                 case 'rectangle':
                     drawBoundingBox(vm, labels_list[i]);
                     break;
+                case 'point':
+                    drawPoint(vm, labels_list[i]);
+                    break;
+                case 'circle':
+                    drawPoint(vm, labels_list[i]);
+                    break;
                 default:
             }
             
         }
     }
+}
+
+export function drawPoint(vm, point) {
+    // console.log("Drawing point");
+    vm = setColor(vm, vm.label_colors[point.label_class], vm.opacity);
+
+    vm.ctx.beginPath();
+    let fstyle = vm.ctx.fillStyle;
+    vm.ctx.fillStyle = fstyle;
+    if (point.selected) {
+        var currentStrokeStyle = vm.ctx.strokeStyle;
+        vm.ctx.strokeStyle = "#FF0000";
+        vm.ctx.setLineDash([4, 4]);
+    }
+    // console.log(point);
+    vm.ctx.arc(point.label.x, point.label.y, point.label.radius, 0, Math.PI*2);
+    vm.ctx.closePath();
+    
+    vm.ctx.stroke();
+    vm.ctx.fill();
+    // vm.ctx.closePath();
+    // vm.ctx.strokeStyle = currentStrokeStyle;
+    vm.ctx.beginPath();
+    vm.ctx.setLineDash([]);
+
+    var currentColour = vm.ctx.currentColour
+
+    if (point.selected) {
+        vm.ctx.fillStyle = "#FF0000"
+    } else {
+        vm.ctx.fillStyle = "#000000"
+    }
+    
+
+    if(point.type == "circle") {
+
+
+        // just a comment
+        // this.setColor([0, 0, 0], 1);
+        vm.ctx.moveTo(point.label.x, point.label.y);
+        vm.ctx.arc(point.label.x, point.label.y, 2 , 0, Math.PI*2);
+
+    }    
+
+    vm.ctx.stroke();
+    vm.ctx.fill();
+
+    vm.ctx.strokeStyle = currentStrokeStyle;
+    vm.ctx.fillStyle = fstyle;
 }
 
 //Polygon or Freehand drawing function
@@ -34,7 +89,6 @@ export function drawPolygon(vm, polygon) {
 
     if (polygon.selected) {
         // draw selected polygon
-
         var currentStrokeStyle = vm.ctx.strokeStyle;
         vm.ctx.strokeStyle = "#FF0000";
         vm.ctx.setLineDash([4, 4]);
@@ -104,4 +158,49 @@ export function drawBoundingBox (vm, box) {
         vm_new.ctx.fill();
     }
     
+}
+
+<<<<<<< HEAD
+export function drawLiveCircle(vm) {
+    if(vm.active_tool != 'circle') {
+        return;
+=======
+//Point drawing function
+export function drawPoint (vm, point) {
+    vm = setColor(vm, vm.label_colors[point.label_class], vm.opacity);
+    if(point.label != null) {
+        vm.ctx.beginPath();
+        let fstyle = vm.ctx.fillStyle;
+        vm.ctx.fillStyle = "rgba(0, 255, 0, 0.2)";
+        vm.ctx.fillStyle = fstyle;
+        vm.ctx.arc(point.label.x, point.label.y, 4, 0, Math.PI*2);
+        vm.ctx.closePath();
+
+        if (point.selected) {
+            var currentStrokeStyle = vm.ctx.strokeStyle;
+            vm.ctx.strokeStyle = "#FF0000";
+            vm.ctx.setLineDash([4, 4]);
+        }
+
+        vm.ctx.stroke_thickness
+        vm.ctx.stroke();
+        vm.ctx.fill();
+        vm.ctx.strokeStyle = currentStrokeStyle;
+        vm.ctx.setLineDash([]);
+>>>>>>> bc31f13... Point label data structure changed
+    }
+    let x = vm.last_mouse_pos[0];
+    let y = vm.last_mouse_pos[1];
+    vm.ctx_live.fillStyle = formatColor(vm.label_colors[vm.active_label], vm.opacity);
+    //vm.ctx.fillStyle = formatColor([0, 255, 0], 0.5);
+    vm.ctx_live.beginPath();
+    vm.ctx_live.moveTo(x + vm.circle_radius, y);
+    vm.ctx_live.arc(x, y, vm.circle_radius , 0, Math.PI*2);
+
+    vm.ctx_live.fill();
+    vm.ctx_live.fillStyle = formatColor([0, 0, 0], 1);
+    vm.ctx_live.moveTo(x, y);
+    vm.ctx_live.arc(x, y, 2 , 0, Math.PI*2);
+    
+    vm.ctx_live.stroke();
 }

--- a/frontend/spa/static/LabelOperations.js
+++ b/frontend/spa/static/LabelOperations.js
@@ -1,5 +1,5 @@
 //returns data structure of a label
-export function getLabel(active_tool, coordPath, coords) {
+export function getLabel(active_tool, coordPath, coords, infos={}) {
     switch (active_tool) {
         case 'freehand':
         case 'polygon':
@@ -14,6 +14,18 @@ export function getLabel(active_tool, coordPath, coords) {
                 boxWidth: coords.x - coordPath[0][0],
                 boxHeight: coords.y - coordPath[0][1]
             }
+        case "point":
+            return {
+                x: coordPath[0][0],
+                y: coordPath[0][1],
+                radius: 4
+            };
+        case "circle":
+            return {
+                x: coordPath[0][0],
+                y: coordPath[0][1],
+                radius: infos['circle_radius']
+            };
         default:
     }
 }
@@ -31,15 +43,16 @@ export function isLabelLargeEnough(active_tool, coordPath) {
             var y_min = Math.min(...coordPath.map(p => p[1]));
             var y_max = Math.max(...coordPath.map(p => p[1]));
 
-            //console.log('x length: ' + Math.abs(x_min - x_max));
-            //console.log('y length: ' + Math.abs(y_min - y_max));
-
             if (Math.abs(x_min - x_max) < 5 || Math.abs(y_min - y_max) < 5) {
                 return false;
             }
             else {
                 return true;
             }
+        case 'point':
+            return true;
+        case 'circle':
+            return true;
         default:
     }
 
@@ -47,11 +60,13 @@ export function isLabelLargeEnough(active_tool, coordPath) {
 
 //determines if selected point lies within any of the stored labels
 export function isPointInLabel(selX, selY, labels) {
+    // console.log(selX + " " + selY)
+    // console.log(labels)
     switch (labels.type) {
         case 'freehand':
         case 'polygon':
             console.log('determining if point is in label type polygon...')
-            for (var count = 0; count < labels.label.regions.length; j++) {
+            for (var count = 0; count < labels.label.regions.length; count++) {
                 var cornersX = labels.label.regions[count].map(p => p[0]);
                 var cornersY = labels.label.regions[count].map(p => p[1]);
 
@@ -88,11 +103,25 @@ export function isPointInLabel(selX, selY, labels) {
             } else {
                 return false;
             }
+        case 'circle':
+            return isPointInCircle(selX, selY, labels.label.x, labels.label.y, labels.label.radius);
+        case 'point':
+            return isPointInCircle(selX, selY, labels.label.x, labels.label.y, 4);
         default:
     }
 }
 
+function isPointInCircle(x, y, cornersX, cornersY, radius) {
+    var euclid_dist = Math.sqrt(Math.pow(x - cornersX, 2) + Math.pow(y - cornersY, 2));
+    if(euclid_dist < radius) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 export function getSelectedLabelIndex(labels) {
+
     //returns the index of the last selected label in the list
     var index = -1;
     
@@ -120,6 +149,14 @@ export function addPaddingOffset(labels, padX, padY) {
                 labels[i].label.x += padX;
                 labels[i].label.y += padY;
                 break;
+            case 'circle':
+                labels[i].label.x += padX;
+                labels[i].label.y += padY;
+                break;
+            case 'point':
+                labels[i].label.x += padX;
+                labels[i].label.y += padY;
+                break;
             default:
         }
     }
@@ -139,6 +176,14 @@ export function removePaddingOffset(labels, padX, padY) {
                 }
                 break;
             case 'rectangle':
+                labels[i].label.x -= padX;
+                labels[i].label.y -= padY;
+                break;
+            case 'circle':
+                labels[i].label.x -= padX;
+                labels[i].label.y -= padY;
+                break;
+            case 'point':
                 labels[i].label.x -= padX;
                 labels[i].label.y -= padY;
                 break;

--- a/frontend/spa/static/label_loading.js
+++ b/frontend/spa/static/label_loading.js
@@ -169,12 +169,9 @@ export async function uploadLabels(input_data_id, label_task_id, polygons) {
     if (label_task_id == undefined || input_data_id == undefined) {
         console.log("Error: Input fields must all be defined in order to upload label:" + label_task_id + input_data_id)
     }
-    // else if (polygons.length == 0) {
-    //     console.error('Polygons object should (probably) not be empty when uploading! Not uploading item.');
-    // }
     else {
         if (polygons.length == 0) {
-                console.warn('Polygons object should (probably) not be empty when uploading! Not uploading item.');
+                console.warn('Labels object should (probably) not be empty when uploading! Not uploading item.');
         }
 
         var data = {label_serialised: polygons}


### PR DESCRIPTION
These commits add the circle and point label types to work with the latest changes on master. Circle type shows user where circle will be placed and allows resizing before placement with either the + and - keys on the numpad (fine control), or with Shift+scroll on the mouse (course control). 

The point label type is functionally the same as the previous pull request, but is more in line with the refactor changes implemented in master. Everything should be in line with how you have organized different types of labels on master.

4th canvas layer ("canvas-live") was added to show previews of user action before they do it. Currently only has a function in the circle label mode, where it renders a preview circle in the canvas-live over the rest of the canvas layers before the user places the circle (to allow them to see the effects of their placement). It does not change any configuration/functioning of the existing layers.