### PR TITLE
Add circle and points with preview on 4th canvas layer (Supersedes #38)

### DIFF
--- a/frontend/spa/src/components/DrawingCanvas.vue
+++ b/frontend/spa/src/components/DrawingCanvas.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="canvas-section" style="position:static; display: inline;">
         <div id="canvasesdiv" style="position:relative;" @mousedown.passive="mouseDownHandler" @mouseup.passive="mouseUpHandler" @mousemove.passive="mouseMoveHandler">
-            
+            <canvas id="canvas-live" width="900" height="350" style="width:900px;height:350px; border: 1px solid #ccc; z-index: 4; position:absolute; left:50%; top:0px; transform: translate(-50%, 0);"></canvas>
             <canvas id="canvas-fg" width="900" height="350" style="width:900px;height:350px; border: 1px solid #ccc; z-index: 3; position:absolute; left:50%; top:0px; transform: translate(-50%, 0);"></canvas>
             <canvas id="canvas-bg" width="900" height="350" style="width:900px;height:350px; border: 1px solid #ccc; z-index: 2; position:absolute; left:50%; top:0px; transform: translate(-50%, 0);"></canvas>
             <canvas id="canvas-pattern" width="900" height="350" style="width:900px;height:350px; border: 1px solid #ccc; z-index: 1; position:absolute; left:50%; top:0px; transform: translate(-50%, 0);"></canvas>
@@ -31,7 +31,10 @@ import { getLabel,
          addPaddingOffset,
          removePaddingOffset } from '../../static/LabelOperations'
 
-import { drawAllLabels } from '../../static/DrawingOperations'
+import { drawAllLabels, drawLiveCircle } from '../../static/DrawingOperations'
+
+import LabelStatus from './LabelStatus'
+//import { extractColor, formatColor } from '../../static/color_utilities'
 
 
 export default {
@@ -101,6 +104,26 @@ export default {
             type: Boolean,
             default: false
         },
+        increase_circle_event: {
+            required: false,
+            type: Boolean,
+            default: false
+        },
+        decrease_circle_event: {
+            required: false,
+            type: Boolean,
+            default: false
+        },
+        change_radio_event: {
+            required: false,
+            type: Boolean,
+            default: false
+        },
+        switch_label_event: {
+            required: false,
+            type: Boolean,
+            default: false
+        }
     },
     data: function() {
         return {
@@ -115,7 +138,10 @@ export default {
             label_status_toggler: {user_complete: false},
             labels: [],
             labels_redo: [],
-            labels_undo: []
+            labels_undo: [],
+            circleFlag: false,
+            circle_radius: 20,
+            last_mouse_pos: []
         };
     },
     // components: {
@@ -136,11 +162,20 @@ export default {
             return this.input_data_id != undefined;
         }
     },
+    beforeMount() {
+        var msScroll = this.onMouseScroll;
+        window.addEventListener('wheel',function(event){
+                msScroll(event);
+                return false; 
+            }, false);
+    },
     mounted() {
         var el = document.getElementById('canvas-fg');
         var el2 = document.getElementById('canvas-bg');
+        var el3 = document.getElementById('canvas-live');
         this.ctx = el.getContext('2d');
         this.ctx_bg = el2.getContext('2d');
+        this.ctx_live = el3.getContext('2d');
 
         console.log('------ mounted page')
 
@@ -190,6 +225,7 @@ export default {
 
         clear_canvas_event: function() {
             this.clearCanvas();
+            this.clearLiveCanvas();
             console.log('clear canvas event occured')
         },
 
@@ -215,9 +251,74 @@ export default {
 
         hide_labels: function() {
             drawAllLabels(this, this.labels);
+        },
+        increase_circle_event: function() {
+            this.inc_circle_size();
+        },
+
+        decrease_circle_event: function() {
+            this.dec_circle_size();
+        },
+
+        switch_label_event: function() {
+            this.rerenderLiveCanvas();
+        },
+
+        change_radio_event: function(){
+            this.radioEvent();
         }
     },
     methods: {
+        inc_circle_size: function(fast_res=false) {
+            if(fast_res) {
+                this.circle_radius += 8;
+            } else {
+                this.circle_radius += 1;
+            }
+            this.clearLiveCanvas();
+            drawLiveCircle(this);
+        },
+
+        dec_circle_size: function(fast_res=false) {
+            if(this.circle_radius != 1){
+                if(fast_res && this.circle_radius > 5) {
+                    this.circle_radius -= 8;
+                } else {
+                    this.circle_radius -= 1;
+                }
+                this.clearLiveCanvas();
+                drawLiveCircle(this);
+            }
+        },
+
+        onMouseScroll: function(e) {
+            var fast_res = false;
+            if(e.shiftKey) {
+                fast_res = true;
+                if(e.deltaY > 0) {
+                    // scrolled up
+                    this.inc_circle_size(fast_res);
+                } else if(e.deltaY < 0 ) {
+                    // scrolled down
+                    this.dec_circle_size(fast_res);
+                }
+                e.stopPropagation();
+                e.preventDefault();
+            } 
+
+
+        },
+
+        rerenderLiveCanvas: function() {
+            //this.drawAllPolygons(this.ctx, this.polygons);
+            this.clearLiveCanvas();
+            drawLiveCircle(this);
+        },
+
+        radioEvent: function() {
+            this.clearLiveCanvas();
+        },
+
         set_labels: function(labels) {
             // the parent component can set the labels using this method in order to load the labels from the backend
 
@@ -249,6 +350,7 @@ export default {
 
             let canvas_bg = document.getElementById("canvas-bg");
             let canvas_fg = document.getElementById("canvas-fg");
+            let canvas_lv = document.getElementById("canvas-live");
             let canvas_pattern = document.getElementById("canvas-pattern");
             let ctx2 = canvas_bg.getContext("2d");  
 
@@ -257,7 +359,7 @@ export default {
 
             this.setCanvasSize(canvas_bg, w, h, this.padX, this.padY);
             this.setCanvasSize(canvas_fg, w, h, this.padX, this.padY);
-
+            this.setCanvasSize(canvas_lv, w, h, this.padX, this.padY);
             ctx2.fillStyle = "hsl(25, 40%, 100%)";
             ctx2.fillRect(this.padX, this.padY, w, h);
 
@@ -340,11 +442,27 @@ export default {
 
                     drawAllLabels(this, this.labels);
                     break;
+                case 'point':  
+                    // mark current point and process it
+                    this.coordPath = [];
+                    this.coordPath.push([coords.x, coords.y]);
+                    this.processLabel(e);
+                    break;
+                case 'circle':  
+                    this.polygons_redo = [];                
+                    this.coordPath = [];
+                    this.coordPath.push([coords.x, coords.y]);
+                    this.processLabel(e);
+                    break;
                 default:
             }
         },
 
         mouseMoveHandler: function (e) {
+            if(this.active_tool == 'circle') {
+                this.isDrawing = true;
+            }
+
             if (this.isDrawing) {
                 var coords = this.getMousePos(this.ctx.canvas, e);
                 if (this.active_tool == 'freehand') {
@@ -365,13 +483,28 @@ export default {
 
                     this.ctx.rect(this.coordPath[0][0], this.coordPath[0][1], coords.x - this.coordPath[0][0], coords.y - this.coordPath[0][1]);
                     this.ctx.stroke();
+                } else if(this.active_tool == 'circle'){
+                    this.last_mouse_pos = [coords.x, coords.y]
+                    // var origin = this.currentPath[0]
+                    this.clearLiveCanvas(); // TODO
+                    drawLiveCircle(this); // TODO
+
+                    if (coords.x == undefined || coords.y == undefined) {
+                        console.log("coords undef:" + coords);
+                    }
                 }
             }
         },
 
         mouseUpHandler: function (e) {
             //processes label if active tool is not selected as polygon
-            if (this.isDrawing && this.active_tool != 'polygon' && this.active_tool != 'point') {
+            if(this.active_tool == 'circle') {
+                return;
+            }
+            if(this.active_tool == 'point') {
+                return;
+            }
+            if (this.isDrawing && this.active_tool != 'polygon') {
                 this.processLabel(e);
             }
         },
@@ -379,7 +512,6 @@ export default {
         processLabel: function (e) {
             this.isDrawing = false;
             this.edited = true;
-
             var coords = this.getMousePos(this.ctx.canvas, e);
             this.coordPath.push([coords.x, coords.y]);
 
@@ -405,8 +537,15 @@ export default {
                     this.labels[i].selected = false;
                 }
             }
+            var infos = {};
+            if(this.active_tool == 'circle') {
+                infos['circle_radius'] = this.circle_radius;
+            }
 
-            let currentLabel = getLabel(this.active_tool, this.coordPath, coords);
+            let currentLabel = getLabel(this.active_tool, this.coordPath, coords, infos);
+            
+            // console.log('currentLabel:');
+            // console.log(currentLabel);
 
             switch (this.active_mode) {
                 case 'new':
@@ -430,7 +569,6 @@ export default {
                                 currentLabel = PolyBool.difference(currentLabel, labl);
                             }
                         }
-
                         if (currentLabel.regions.length > 0) {
                             this.labels.push({ 'label': currentLabel, 'label_class': this.active_label, 'type': this.active_tool, 'selected': true });
                         }
@@ -493,7 +631,6 @@ export default {
             }
 
             this.coordPath = [];
-
             drawAllLabels(this, this.labels);
         },
 
@@ -503,8 +640,10 @@ export default {
             this.labels_redo = [];
             this.edited = true;
         },
-
-        // image displaying functions
+        
+        clearLiveCanvas: function() {
+            this.ctx_live.clearRect(0, 0, this.ctx_live.canvas.width, this.ctx_live.canvas.height);
+        },
 
         validateResponse: function (response) {
             if (!response.ok) {
@@ -525,6 +664,7 @@ export default {
         },
 
         showImage: function (responseAsBlob) {
+            let canvas_live = document.getElementById("canvas-live");
             let canvas_fg = document.getElementById("canvas-fg");
             let canvas_bg = document.getElementById("canvas-bg");
             let ctx2 = canvas_bg.getContext("2d");
@@ -537,6 +677,7 @@ export default {
             var vm = this;
 
             img.onload = function () {
+                vm.setCanvasSize(canvas_live, img.width, img.height, vm.padX, vm.padY);
                 vm.setCanvasSize(canvas_fg, img.width, img.height, vm.padX, vm.padY);
                 vm.setCanvasSize(canvas_bg, img.width, img.height, vm.padX, vm.padY);
 

--- a/frontend/spa/src/components/ImageLabeling.vue
+++ b/frontend/spa/src/components/ImageLabeling.vue
@@ -5,7 +5,7 @@
             <div class="row justify-content-center">
                 <div id="tools" class="col border-right">
                     <span>Tools</span>
-                    <form id="tools_form">
+                    <form id="tools_form" @mousedown=changeRadio()>
                         <input type="radio" class="radio-button" name="tool" value="freehand" v-model="active_tool"> Freehand
                         <br>
                         <input type="radio" class="radio-button" name="tool" value="polygon" v-model="active_tool"> Polygon
@@ -13,6 +13,8 @@
                         <input type="radio" class="radio-button" name="tool" value="rectangle" v-model="active_tool"> Rectangle
                         <br>
                         <input type="radio" class="radio-button" name="tool" value="point" v-model="active_tool"> Point
+                        <br>
+                        <input type="radio" class="radio-button" name="tool" value="circle" v-model="active_tool"> Circle
                         <br>
                         <input type="radio" class="radio-button" name="tool" value="select" v-model="active_tool"> Select
                     </form>
@@ -107,6 +109,10 @@
                             v-bind:undo_event="undo_event"
                             v-bind:redo_event="redo_event"
                             v-bind:hide_labels="hide_labels"
+                            v-bind:increase_circle_event="increase_circle_event"
+                            v-bind:decrease_circle_event="decrease_circle_event"
+                            v-bind:change_radio_event ="change_radio_event"
+                            v-bind:switch_label_event="switch_label_event"
                             ref="mySubComponent"
                             class="row"
                             ></drawing-canvas>
@@ -174,6 +180,10 @@ export default {
             undo_event: false,
             redo_event: false,
             hide_labels: false,
+            increase_circle_event: false,
+            decrease_circle_event: false,
+            switch_label_event: false,
+            change_radio_event:false,
             label_examples: undefined,
             baseUrl: baseUrl,
             keyboard_shortcuts: [
@@ -256,6 +266,24 @@ export default {
                     this.stateOverlap = false;
                     this.stateNoOverlap = true;
                     break;
+                case 'point':
+                    this.active_mode = 'new';
+                    this.active_overlap_mode = 'overlap';
+                    this.stateNew = false;
+                    this.stateAppend = true;
+                    this.stateErase = true;
+                    this.stateOverlap = false;
+                    this.stateNoOverlap = true;
+                    break;
+                case 'circle':
+                    this.active_mode = 'new';
+                    this.active_overlap_mode = 'overlap';
+                    this.stateNew = false;
+                    this.stateAppend = true;
+                    this.stateErase = true;
+                    this.stateOverlap = false;
+                    this.stateNoOverlap = true;
+                    break;
                 case 'select':
                     this.stateNew = true;
                     this.stateAppend = true;
@@ -263,6 +291,7 @@ export default {
                     this.stateOverlap = true;
                     this.stateNoOverlap = true;
                     break;
+                
             }
         }
     },
@@ -483,10 +512,18 @@ export default {
                 }
 
                 key_handled = true;
+            } 
+            else if(e.code === 'NumpadAdd') {
+                this.increase_circle_event = !this.increase_circle_event;
+                key_handled = true;
+            } 
+            else if(e.code === 'NumpadSubtract') {
+                this.decrease_circle_event = !this.decrease_circle_event;
+                key_handled = true;
             }
             if ((e.keyCode >= 48 && e.keyCode <= 57) || (e.keyCode >= 96 && e.keyCode <= 105)) { 
                 // 0-9 only
-
+                this.switch_label_event = !this.switch_label_event;
                 let label_index = e.keyCode - 48;
 
                 if (label_index >= 1 && label_index <= this.labels.length) {
@@ -498,6 +535,7 @@ export default {
                     }
                 }
             }
+
 
             if (key_handled) {
                 e.stopPropagation();
@@ -547,6 +585,9 @@ export default {
         clearCanvas: function() {
             this.clear_canvas_event = !this.clear_canvas_event;
             console.log('clear canvas called', this.clear_canvas_event)
+        },
+        changeRadio: function(){
+            this.change_radio_event = !this.change_radio_event;
         },
 
     },

--- a/frontend/spa/static/DrawingOperations.js
+++ b/frontend/spa/static/DrawingOperations.js
@@ -23,11 +23,63 @@ export function drawAllLabels(vm, labels_list) {
                 case 'point':
                     drawPoint(vm, labels_list[i]);
                     break;
+                case 'circle':
+                    drawPoint(vm, labels_list[i]);
+                    break;
                 default:
             }
             
         }
     }
+}
+
+export function drawPoint(vm, point) {
+    // console.log("Drawing point");
+    vm = setColor(vm, vm.label_colors[point.label_class], vm.opacity);
+
+    vm.ctx.beginPath();
+    let fstyle = vm.ctx.fillStyle;
+    vm.ctx.fillStyle = fstyle;
+    if (point.selected) {
+        var currentStrokeStyle = vm.ctx.strokeStyle;
+        vm.ctx.strokeStyle = "#FF0000";
+        vm.ctx.setLineDash([4, 4]);
+    }
+    // console.log(point);
+    vm.ctx.arc(point.label.x, point.label.y, point.label.radius, 0, Math.PI*2);
+    vm.ctx.closePath();
+    
+    vm.ctx.stroke();
+    vm.ctx.fill();
+    // vm.ctx.closePath();
+    // vm.ctx.strokeStyle = currentStrokeStyle;
+    vm.ctx.beginPath();
+    vm.ctx.setLineDash([]);
+
+    var currentColour = vm.ctx.currentColour
+
+    if (point.selected) {
+        vm.ctx.fillStyle = "#FF0000"
+    } else {
+        vm.ctx.fillStyle = "#000000"
+    }
+    
+
+    if(point.type == "circle") {
+
+
+        // just a comment
+        // this.setColor([0, 0, 0], 1);
+        vm.ctx.moveTo(point.label.x, point.label.y);
+        vm.ctx.arc(point.label.x, point.label.y, 2 , 0, Math.PI*2);
+
+    }    
+
+    vm.ctx.stroke();
+    vm.ctx.fill();
+
+    vm.ctx.strokeStyle = currentStrokeStyle;
+    vm.ctx.fillStyle = fstyle;
 }
 
 //Polygon or Freehand drawing function
@@ -108,27 +160,22 @@ export function drawBoundingBox (vm, box) {
     
 }
 
-//Point drawing function
-export function drawPoint (vm, point) {
-    vm = setColor(vm, vm.label_colors[point.label_class], vm.opacity);
-    if(point.label != null) {
-        vm.ctx.beginPath();
-        let fstyle = vm.ctx.fillStyle;
-        vm.ctx.fillStyle = "rgba(0, 255, 0, 0.2)";
-        vm.ctx.fillStyle = fstyle;
-        vm.ctx.arc(point.label.x, point.label.y, 4, 0, Math.PI*2);
-        vm.ctx.closePath();
-
-        if (point.selected) {
-            var currentStrokeStyle = vm.ctx.strokeStyle;
-            vm.ctx.strokeStyle = "#FF0000";
-            vm.ctx.setLineDash([4, 4]);
-        }
-
-        vm.ctx.stroke_thickness
-        vm.ctx.stroke();
-        vm.ctx.fill();
-        vm.ctx.strokeStyle = currentStrokeStyle;
-        vm.ctx.setLineDash([]);
+export function drawLiveCircle(vm) {
+    if(vm.active_tool != 'circle') {
+        return;
     }
+    let x = vm.last_mouse_pos[0];
+    let y = vm.last_mouse_pos[1];
+    vm.ctx_live.fillStyle = formatColor(vm.label_colors[vm.active_label], vm.opacity);
+    //vm.ctx.fillStyle = formatColor([0, 255, 0], 0.5);
+    vm.ctx_live.beginPath();
+    vm.ctx_live.moveTo(x + vm.circle_radius, y);
+    vm.ctx_live.arc(x, y, vm.circle_radius , 0, Math.PI*2);
+
+    vm.ctx_live.fill();
+    vm.ctx_live.fillStyle = formatColor([0, 0, 0], 1);
+    vm.ctx_live.moveTo(x, y);
+    vm.ctx_live.arc(x, y, 2 , 0, Math.PI*2);
+    
+    vm.ctx_live.stroke();
 }

--- a/frontend/spa/static/LabelOperations.js
+++ b/frontend/spa/static/LabelOperations.js
@@ -1,5 +1,5 @@
 //returns data structure of a label
-export function getLabel(active_tool, coordPath, coords) {
+export function getLabel(active_tool, coordPath, coords, infos={}) {
     switch (active_tool) {
         case 'freehand':
         case 'polygon':
@@ -14,11 +14,18 @@ export function getLabel(active_tool, coordPath, coords) {
                 boxWidth: coords.x - coordPath[0][0],
                 boxHeight: coords.y - coordPath[0][1]
             }
-        case 'point':
+        case "point":
             return {
-                x: coords.x,
-                y: coords.y
-            }
+                x: coordPath[0][0],
+                y: coordPath[0][1],
+                radius: 4
+            };
+        case "circle":
+            return {
+                x: coordPath[0][0],
+                y: coordPath[0][1],
+                radius: infos['circle_radius']
+            };
         default:
     }
 }
@@ -42,6 +49,10 @@ export function isLabelLargeEnough(active_tool, coordPath) {
             else {
                 return true;
             }
+        case 'point':
+            return true;
+        case 'circle':
+            return true;
         default:
     }
 
@@ -92,21 +103,25 @@ export function isPointInLabel(selX, selY, labels) {
             } else {
                 return false;
             }
+        case 'circle':
+            return isPointInCircle(selX, selY, labels.label.x, labels.label.y, labels.label.radius);
         case 'point':
-                var cornersX = labels.label.x;
-                var cornersY = labels.label.y;
-
-                var euclid_dist = Math.sqrt(Math.pow(selX - cornersX, 2) + Math.pow(selY - cornersY, 2));
-                if(euclid_dist < 5) {
-                    return true;
-                } else {
-                    return false;
-                }
+            return isPointInCircle(selX, selY, labels.label.x, labels.label.y, 4);
         default:
     }
 }
 
+function isPointInCircle(x, y, cornersX, cornersY, radius) {
+    var euclid_dist = Math.sqrt(Math.pow(x - cornersX, 2) + Math.pow(y - cornersY, 2));
+    if(euclid_dist < radius) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 export function getSelectedLabelIndex(labels) {
+
     //returns the index of the last selected label in the list
     var index = -1;
     
@@ -134,6 +149,14 @@ export function addPaddingOffset(labels, padX, padY) {
                 labels[i].label.x += padX;
                 labels[i].label.y += padY;
                 break;
+            case 'circle':
+                labels[i].label.x += padX;
+                labels[i].label.y += padY;
+                break;
+            case 'point':
+                labels[i].label.x += padX;
+                labels[i].label.y += padY;
+                break;
             default:
         }
     }
@@ -153,6 +176,14 @@ export function removePaddingOffset(labels, padX, padY) {
                 }
                 break;
             case 'rectangle':
+                labels[i].label.x -= padX;
+                labels[i].label.y -= padY;
+                break;
+            case 'circle':
+                labels[i].label.x -= padX;
+                labels[i].label.y -= padY;
+                break;
+            case 'point':
                 labels[i].label.x -= padX;
                 labels[i].label.y -= padY;
                 break;


### PR DESCRIPTION
These commits add the circle and point label types to work with the latest changes on master. Circle type shows user where circle will be placed and allows resizing before placement with either the + and - keys on the numpad (fine control), or with Shift+scroll on the mouse (course control).

The point label type is functionally the same as the previous pull request, but is more in line with the refactor changes implemented in master. Everything should be in line with how you have organized different types of labels on master.

4th canvas layer ("canvas-live") was added to show previews of user action before they do it. Currently only has a function in the circle label mode, where it renders a preview circle in the canvas-live over the rest of the canvas layers before the user places the circle (to allow them to see the effects of their placement). It does not change any configuration/functioning of the existing layers.

Note: this PR supersedes PR #38 