### PR TITLE
Fix the select function at different zoom levels

### DIFF
--- a/frontend/spa/src/components/DrawingCanvas.vue
+++ b/frontend/spa/src/components/DrawingCanvas.vue
@@ -479,7 +479,7 @@ export default {
                     // check which labels the point lies within
                     for (var i = 0; i < this.labels.length; i++) {
                         var selected = false;
-                        if (isPointInLabel(coords.x, coords.y, this.labels[i]))
+                        if (isPointInLabel(tmpX, tmpY, this.labels[i]))
                         {
                             this.labels[i].selected = true;
                         } else {


### PR DESCRIPTION
Determine if label should be selected using coordinates at 100% zoom level.